### PR TITLE
Reorder endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -184,6 +184,20 @@ def checkout_quantity(product_id, condition):
     existing_record.checkout(data)
     return jsonify(existing_record.serialize()), status.HTTP_200_OK
 
+
+@app.route("/inventory/reorder/<int:product_id>/<condition>", methods=["PUT"])
+def reorder_quantity(product_id, condition):
+    """Increases quantity from inventory of a particular item based on the amount specified by user"""
+    app.logger.info(f"Reorder called for product id: {product_id}, condition: {condition}")
+
+    data = request.get_json()
+    existing_record = Inventory.find((product_id, condition))
+    if not existing_record:
+        abort(status.HTTP_404_NOT_FOUND, f"Product with id '{product_id}' was not found.")
+    existing_record.reorder(data)
+    return jsonify(existing_record.serialize()), status.HTTP_200_OK
+
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
@@ -206,9 +220,3 @@ def check_content_type(content_type):
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
-
-def find_from_request_json(request_body):
-    '''Fetch relevant items based on product ID and condition'''
-    inventory = Inventory()
-    inventory.deserialize(request_body)
-    return Inventory.find((inventory.product_id, inventory.condition))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -216,7 +216,7 @@ class TestInventory(unittest.TestCase):
 
         data = {}
         data["ordered_quantity"] = "1"
-        self.assertRaises(OutOfRangeError, record.checkout, data)
+        self.assertRaises(DataValidationError, record.checkout, data)
     
     def test_checkout_exceed_exeception(self):
         """Test for checkout exceed exception"""
@@ -229,3 +229,25 @@ class TestInventory(unittest.TestCase):
         data = {}
         data["ordered_quantity"] = original_quantity + 1
         self.assertRaises(OutOfRangeError, record.checkout, data)
+
+
+    def test_reorder(self):
+        """Test for reorder success"""
+        record = InventoryFactory()
+        record.create()
+        record.active = True
+        self.assertIsNotNone(record.product_id)
+
+        # reorder succeeds
+        original_quantity = record.quantity
+        data = {"ordered_quantity": 1}
+        record.reorder(data)
+        self.assertEqual(record.quantity - original_quantity, 1)
+
+        # reorder fails with invalid data type
+        self.assertRaises(DataValidationError, record.reorder, {})
+        self.assertRaises(DataValidationError, record.reorder, {"ordered_quantity": "1"})
+
+        # reorder fails when record is inactive
+        record.active = False
+        self.assertRaises(InactiveRecordError, record.reorder, data)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -415,7 +415,7 @@ class TestInventory(TestCase):
             "Quantity=%s: %d = %s", test_quantity, len(quantity_list), quantity_list
         )
         resp = self.client.get(BASE_URL, query_string=f"quantity={str(test_quantity)}&operator={test_operator}")
-        if(len(quantity_list)>0):
+        if len(quantity_list) > 0:
             self.assertEqual(resp.status_code, status.HTTP_200_OK)
             data = resp.get_json()
             self.assertEqual(len(data), len(quantity_list))
@@ -423,7 +423,7 @@ class TestInventory(TestCase):
             for record in data:
                 self.assertLess(record["quantity"], test_quantity)
         else:
-            self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_query_inventories_by_less_than_equal_quantity(self):
         """It should Query Inventories by Less Than Equal to Quantity Individually"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -534,6 +534,32 @@ class TestInventory(TestCase):
                                    json=request_dict)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
     
+
+    def test_reorder(self):
+        """"Test for cases when reorder endpoint is called"""
+        record = InventoryFactory()
+        record.active = True
+        response = self.client.post(BASE_URL, json=record.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        request_body = {"ordered_quantity": 1}
+        expected_data = record.serialize()
+        expected_data["quantity"] += request_body["ordered_quantity"]
+
+        # success: 200
+        url = f"{BASE_URL}/reorder/{record.product_id}/{record.condition.name}"
+        response = self.client.put(url, json=request_body)
+        actual_data = response.get_json()
+
+        self.assertEqual(actual_data, expected_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # product not found: 404
+        url = f"{BASE_URL}/reorder/{record.product_id+1}/{record.condition.name}"
+        response = self.client.put(url, json=request_body)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
     # def test_checkout_success(self):
     #     """Test for cases when the checkout feature executes successfully
     #     when ordered quantity is less than quantity of item in the database"""


### PR DESCRIPTION
#77

- Refactored common code for type checking in `checkout` and `reorder` into a function `validate_ordered_quantity `.
- Added a `reorder` function in models to perform the logic.
- Added a route `PUT /inventory/reorder/{product_id}/{condition}`.
- Added tests for functions in models and routes, covering happy and sad paths. 
